### PR TITLE
Add attributions & rewrite links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,7 @@
 # phoenixrose
+
 phoenixrose (ph03nixr0s3) public page
+
+## Attributions
+
+Original website implementations by [nilllzz](https://nilllzz.dev).

--- a/docs/index.html
+++ b/docs/index.html
@@ -14,21 +14,24 @@
         <meta property="og:description" content="I stream and make music" />
         <meta
             property="og:image"
-            content="https://nilllzz.github.io/phoenixrose/img/og_image.jpg"
+            content="https://ph03nixr0s3live.github.io/ph03nixr0s3.live/img/og_image.jpg"
         />
         <meta property="og:image:width" content="1000" />
         <meta property="og:image:height" content="540" />
-        <meta property="og:url" content="https://nilllzz.github.io/phoenixrose/" />
+        <meta property="og:url" content="https://ph03nixr0s3live.github.io/ph03nixr0s3.live/" />
         <meta property="profile:username" content="ph03nixr0s3" />
 
         <!-- Twitter tags -->
         <meta property="twitter:card" content="summary_large_image" />
         <meta property="twitter:title" content="PhoenixRoseLIVE" />
         <meta property="twitter:description" content="I stream and make music" />
-        <meta property="twitter:url" content="https://nilllzz.github.io/phoenixrose/" />
+        <meta
+            property="twitter:url"
+            content="https://ph03nixr0s3live.github.io/ph03nixr0s3.live/"
+        />
         <meta
             property="twitter:image"
-            content="https://nilllzz.github.io/phoenixrose/img/og_image.jpg"
+            content="https://ph03nixr0s3live.github.io/ph03nixr0s3.live/img/og_image.jpg"
         />
 
         <link
@@ -40,8 +43,6 @@
     </head>
 
     <body>
-        <script src="./index.js"></script>
-
         <main>
             <header>
                 <img
@@ -67,7 +68,7 @@
                     <h3>How to connect to Rose S.M.P.</h3>
                     <ol>
                         <li>
-                            Players have to authorize through
+                            Twitch Subscribers have to authorize through
                             <a
                                 href="https://linknsync.live/"
                                 target="_blank"
@@ -145,7 +146,15 @@
                 </div>
             </section>
 
-            <footer>Copyright &copy; 2024</footer>
+            <footer>
+                <span>Copyright &copy; <span id="copyright-year">2024</span></span>
+                •
+                <span>
+                    Website implemented by
+                    <a href="https://nilllzz.dev" target="_blank">nilllzz</a>
+                </span>
+            </footer>
+            <script src="./index.js"></script>
         </main>
     </body>
 </html>

--- a/docs/index.js
+++ b/docs/index.js
@@ -9,3 +9,6 @@ async function copyToClipboard(text) {
         console.error("Failed to copy to clipboard", error);
     }
 }
+
+const copyrightYearEl = document.getElementById("copyright-year");
+copyrightYearEl.innerText = new Date().getFullYear();


### PR DESCRIPTION
Adds attributions to the site itself and the README.MD document referring back to me.

Also rewrites meta links to refer to assets on this github user.

Implements a small Javascript function to set the copyright year to the current year.